### PR TITLE
[Front] feat: 프로필 생성 멀티스텝 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
+    "@lottiefiles/dotlottie-react": "^0.12.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.46.2",
     "@tanstack/react-query": "^5.61.5",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,7 +5,7 @@ import { Global } from '@emotion/react';
 import { globalStyles } from '@/shared/styles/global';
 import styled from '@emotion/styled';
 
-import Button from '@/shared/components/buttons/button';
+import Nickname from '@/shared/components/profile-step/nickname';
 export default function ProfilePage() {
   const queryClient = new QueryClient();
 
@@ -13,20 +13,7 @@ export default function ProfilePage() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Global styles={globalStyles} />
       <Section>
-        <Header>
-          <div>회원님의 </div>
-          <div>닉네임을 알려주세요</div>
-        </Header>
-        <Input />
-
-        <ButtonWrapper>
-          <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
-            등록하기
-          </Button>
-          <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
-            건너뛰기
-          </Button>
-        </ButtonWrapper>
+        <Nickname />
       </Section>
     </HydrationBoundary>
   );
@@ -39,28 +26,4 @@ const Section = styled.section`
   justify-content: space-between; 
   height: 100%;
   padding:20px;
-`;
-
-const Header = styled.header`
-  width: 100%;
-  padding: 10px 0;
-  font-size: 20px;
-  font-weight: 600;
-`;
-
-const Input = styled.input`
-  margin-top: 10px;
-  width:100%;
-  min-height:34px;
-  border:2px solid #DEE2E6;
-  border-radius: 20px;
-  background-color: #F8F9FA;
-`;
-
-const ButtonWrapper = styled.div`
-display: flex;
-flex-direction: column;
-gap:10px;
-margin-top: auto;
-margin-bottom: 20px; 
 `;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,14 +10,31 @@ import BodyInfo from '@/shared/components/profile-step/bodyInfo';
 import BmiResult from '@/shared/components/profile-step/bmiResult';
 import GoalWeight from '@/shared/components/profile-step/goalWeight';
 import Start from '@/shared/components/profile-step/start';
+import { useState } from 'react';
+
+const steps = ['Nickname', 'BodyInfo', 'BmiResult', 'GoalWeight', 'Start'];
+
 export default function ProfilePage() {
   const queryClient = new QueryClient();
+  const [step, setStep] = useState(0);
+
+  const onNext = () => {
+    setStep((prev) => prev + 1);
+  };
+
+  // const onPrev = () => {
+  //   setStep((prev) => prev - 1);
+  // };
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Global styles={globalStyles} />
       <Section>
-        <Start />
+        {steps[step] === 'Nickname' && <Nickname onNext={onNext} />}
+        {steps[step] === 'BodyInfo' && <BodyInfo onNext={onNext} />}
+        {steps[step] === 'BmiResult' && <BmiResult onNext={onNext} />}
+        {steps[step] === 'GoalWeight' && <GoalWeight onNext={onNext} />}
+        {steps[step] === 'Start' && <Start onNext={onNext} />}
       </Section>
     </HydrationBoundary>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -17,7 +17,7 @@ export default function ProfilePage() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Global styles={globalStyles} />
       <Section>
-        <Nickname />
+        <Start />
       </Section>
     </HydrationBoundary>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,6 +6,10 @@ import { globalStyles } from '@/shared/styles/global';
 import styled from '@emotion/styled';
 
 import Nickname from '@/shared/components/profile-step/nickname';
+import BodyInfo from '@/shared/components/profile-step/bodyInfo';
+import BmiResult from '@/shared/components/profile-step/bmiResult';
+import GoalWeight from '@/shared/components/profile-step/goalWeight';
+import Start from '@/shared/components/profile-step/start';
 export default function ProfilePage() {
   const queryClient = new QueryClient();
 

--- a/src/shared/components/profile-step/bmiResult.tsx
+++ b/src/shared/components/profile-step/bmiResult.tsx
@@ -1,0 +1,43 @@
+'use client';
+import styled from '@emotion/styled';
+
+import Button from '@/shared/components/buttons/button';
+export default function BmiResult() {
+  return (
+    <>
+      <Header>
+        <div>오연님의 BMI 수치를 </div>
+        <div>분석한 결과</div>
+        <div>
+          현재 <Bmi>저체중</Bmi>입니다
+        </div>
+      </Header>
+      <div>체중 그래프</div>
+
+      <ButtonWrapper>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          알겠어요
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const Bmi = styled.span`
+color: blue;
+`;
+
+const ButtonWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+margin-top: auto;
+margin-bottom: 20px; 
+`;

--- a/src/shared/components/profile-step/bmiResult.tsx
+++ b/src/shared/components/profile-step/bmiResult.tsx
@@ -2,7 +2,12 @@
 import styled from '@emotion/styled';
 
 import Button from '@/shared/components/buttons/button';
-export default function BmiResult() {
+
+type StepProps = {
+  onNext: () => void;
+};
+
+export default function BmiResult({ onNext }: StepProps) {
   return (
     <>
       <Header>
@@ -15,7 +20,7 @@ export default function BmiResult() {
       <div>체중 그래프</div>
 
       <ButtonWrapper>
-        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+        <Button onClick={onNext} $width={100} $height={20} $fontSize={12} $variant='mint'>
           알겠어요
         </Button>
       </ButtonWrapper>

--- a/src/shared/components/profile-step/bodyInfo.tsx
+++ b/src/shared/components/profile-step/bodyInfo.tsx
@@ -2,7 +2,12 @@
 import styled from '@emotion/styled';
 
 import Button from '@/shared/components/buttons/button';
-export default function BodyInfo() {
+
+type StepProps = {
+  onNext: () => void;
+};
+
+export default function BodyInfo({ onNext }: StepProps) {
   return (
     <>
       <Header>
@@ -20,7 +25,7 @@ export default function BodyInfo() {
         </div>
       </InputWrapper>
       <ButtonWrapper>
-        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+        <Button onClick={onNext} $width={100} $height={20} $fontSize={12} $variant='mint'>
           등록하기
         </Button>
       </ButtonWrapper>

--- a/src/shared/components/profile-step/bodyInfo.tsx
+++ b/src/shared/components/profile-step/bodyInfo.tsx
@@ -1,0 +1,60 @@
+'use client';
+import styled from '@emotion/styled';
+
+import Button from '@/shared/components/buttons/button';
+export default function BodyInfo() {
+  return (
+    <>
+      <Header>
+        <div>현재 신체 정보를 </div>
+        <div>입력해 주세요</div>
+      </Header>
+      <InputWrapper>
+        <div>
+          <Input />
+          cm
+        </div>
+        <div>
+          <Input />
+          kg
+        </div>
+      </InputWrapper>
+      <ButtonWrapper>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          등록하기
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const InputWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+
+`;
+
+const Input = styled.input`
+  margin-top: 10px;
+  width:40%;
+  min-height:34px;
+  border:2px solid #DEE2E6;
+  border-radius: 20px;
+  background-color: #F8F9FA;
+`;
+
+const ButtonWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+margin-top: auto;
+margin-bottom: 20px; 
+`;

--- a/src/shared/components/profile-step/goalWeight.tsx
+++ b/src/shared/components/profile-step/goalWeight.tsx
@@ -1,0 +1,54 @@
+'use client';
+import styled from '@emotion/styled';
+
+import Button from '@/shared/components/buttons/button';
+export default function GoalWeight() {
+  return (
+    <>
+      <Header>
+        <div>목표 체중을 </div>
+        <div>입력해 주세요</div>
+      </Header>
+      <InputWrapper>
+        <div>
+          <Input />
+          kg
+        </div>
+      </InputWrapper>
+
+      <ButtonWrapper>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          등록하기
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const InputWrapper = styled.div`
+display: flex;
+`;
+
+const Input = styled.input`
+  margin-top: 10px;
+  width:40%;
+  min-height:34px;
+  border:2px solid #DEE2E6;
+  border-radius: 20px;
+  background-color: #F8F9FA;
+`;
+
+const ButtonWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+margin-top: auto;
+margin-bottom: 20px; 
+`;

--- a/src/shared/components/profile-step/goalWeight.tsx
+++ b/src/shared/components/profile-step/goalWeight.tsx
@@ -2,7 +2,12 @@
 import styled from '@emotion/styled';
 
 import Button from '@/shared/components/buttons/button';
-export default function GoalWeight() {
+
+type StepProps = {
+  onNext: () => void;
+};
+
+export default function GoalWeight({ onNext }: StepProps) {
   return (
     <>
       <Header>
@@ -17,7 +22,7 @@ export default function GoalWeight() {
       </InputWrapper>
 
       <ButtonWrapper>
-        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+        <Button onClick={onNext} $width={100} $height={20} $fontSize={12} $variant='mint'>
           등록하기
         </Button>
       </ButtonWrapper>

--- a/src/shared/components/profile-step/nickname.tsx
+++ b/src/shared/components/profile-step/nickname.tsx
@@ -1,0 +1,48 @@
+'use client';
+import styled from '@emotion/styled';
+
+import Button from '@/shared/components/buttons/button';
+export default function Nickname() {
+  return (
+    <>
+      <Header>
+        <div>회원님의 </div>
+        <div>닉네임을 알려주세요</div>
+      </Header>
+      <Input />
+
+      <ButtonWrapper>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          등록하기
+        </Button>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          건너뛰기
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const Input = styled.input`
+  margin-top: 10px;
+  width:100%;
+  min-height:34px;
+  border:2px solid #DEE2E6;
+  border-radius: 20px;
+  background-color: #F8F9FA;
+`;
+
+const ButtonWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+margin-top: auto;
+margin-bottom: 20px; 
+`;

--- a/src/shared/components/profile-step/nickname.tsx
+++ b/src/shared/components/profile-step/nickname.tsx
@@ -2,7 +2,12 @@
 import styled from '@emotion/styled';
 
 import Button from '@/shared/components/buttons/button';
-export default function Nickname() {
+
+type StepProps = {
+  onNext: () => void;
+};
+
+export default function Nickname({ onNext }: StepProps) {
   return (
     <>
       <Header>
@@ -12,7 +17,7 @@ export default function Nickname() {
       <Input />
 
       <ButtonWrapper>
-        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+        <Button onClick={onNext} $width={100} $height={20} $fontSize={12} $variant='mint'>
           등록하기
         </Button>
         <Button $width={100} $height={20} $fontSize={12} $variant='mint'>

--- a/src/shared/components/profile-step/start.tsx
+++ b/src/shared/components/profile-step/start.tsx
@@ -4,7 +4,12 @@ import styled from '@emotion/styled';
 import Button from '@/shared/components/buttons/button';
 
 import { DotLottieReact } from '@lottiefiles/dotlottie-react';
-export default function Start() {
+
+type StepProps = {
+  onNext: () => void;
+};
+
+export default function Start({ onNext }: StepProps) {
   return (
     <>
       <Header>
@@ -14,7 +19,7 @@ export default function Start() {
       <DotLottieReact src='https://lottie.host/d68bf360-518c-4159-affc-21fe973cfd73/1Jq4dn6dE2.lottie' loop autoplay />
 
       <ButtonWrapper>
-        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+        <Button onClick={onNext} $width={100} $height={20} $fontSize={12} $variant='mint'>
           시작하기
         </Button>
       </ButtonWrapper>

--- a/src/shared/components/profile-step/start.tsx
+++ b/src/shared/components/profile-step/start.tsx
@@ -1,0 +1,35 @@
+'use client';
+import styled from '@emotion/styled';
+
+import Button from '@/shared/components/buttons/button';
+export default function Start() {
+  return (
+    <>
+      <Header>
+        <div>자 이제 운동을 </div>
+        <div>시작해볼까요?</div>
+      </Header>
+
+      <ButtonWrapper>
+        <Button $width={100} $height={20} $fontSize={12} $variant='mint'>
+          시작하기
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const ButtonWrapper = styled.div`
+display: flex;
+flex-direction: column;
+gap:10px;
+margin-top: auto;
+margin-bottom: 20px; 
+`;

--- a/src/shared/components/profile-step/start.tsx
+++ b/src/shared/components/profile-step/start.tsx
@@ -2,6 +2,8 @@
 import styled from '@emotion/styled';
 
 import Button from '@/shared/components/buttons/button';
+
+import { DotLottieReact } from '@lottiefiles/dotlottie-react';
 export default function Start() {
   return (
     <>
@@ -9,6 +11,7 @@ export default function Start() {
         <div>자 이제 운동을 </div>
         <div>시작해볼까요?</div>
       </Header>
+      <DotLottieReact src='https://lottie.host/d68bf360-518c-4159-affc-21fe973cfd73/1Jq4dn6dE2.lottie' loop autoplay />
 
       <ButtonWrapper>
         <Button $width={100} $height={20} $fontSize={12} $variant='mint'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,6 +394,18 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lottiefiles/dotlottie-react@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-react/-/dotlottie-react-0.12.0.tgz#2accb771470fbc38771e7872c1f29353c00e7dde"
+  integrity sha512-33Tsd67vlotrm43R8oko30Krwyuqb0YdOLra7L5m2mVfrTvDPEDBt8jfjgiveoLJ0jG/FlTLiCPXi/vCaBSXrg==
+  dependencies:
+    "@lottiefiles/dotlottie-web" "0.38.2"
+
+"@lottiefiles/dotlottie-web@0.38.2":
+  version "0.38.2"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-web/-/dotlottie-web-0.38.2.tgz#fa97288443f695f6bb76f9e632eb83cd255a2874"
+  integrity sha512-01d+UjJ8NG7ZStYQxtb8FPzknzGmauG7gEkcH+wHfSdiSQJY9PoBNVSTB9V6F5hAnmFqOxaocTtd7TIEEnzMnA==
+
 "@next/env@15.0.3":
   version "15.0.3"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-15.0.3.tgz#a2e9bf274743c52b74d30f415f3eba750d51313a"


### PR DESCRIPTION
-프로필 생성 단계별 컴포넌트로 분리: ['Nickname', 'BodyInfo', 'BmiResult', 'GoalWeight', 'Start']
-@lottiefiles/dotlottie-react 설치: Start컴포넌트에 들어갈 이미지
-멀티스텝 기능(css 추가 수정 필요) 